### PR TITLE
Make udev rule systemd friendly

### DIFF
--- a/fobos-sdr.rules
+++ b/fobos-sdr.rules
@@ -16,5 +16,5 @@
 #
 
 # original Fobos SDR
-ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="132e", MODE="0660", GROUP="plugdev"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="132e", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
Most distros use systemd service management these days. For them the idiomatic way to make device available to the logged in users is to use `uaccess` TAG in the udev rule, see section 4.2 of https://wiki.archlinux.org/title/udev .