### PR TITLE
Don't include `GrPlatform` since its deprecated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ include(GrCompilerSettings)
 ########################################################################
 include(GrVersion)
 
-include(GrPlatform) #define LIB_SUFFIX
+include(GNUInstallDirs)
 
 if(NOT CMAKE_MODULES_DIR)
   set(CMAKE_MODULES_DIR lib${LIB_SUFFIX}/cmake)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,7 +7,7 @@
 ########################################################################
 # Setup library
 ########################################################################
-include(GrPlatform) #define LIB_SUFFIX
+include(GNUInstallDirs)
 
 list(APPEND RigExpert_sources
     fobos_sdr_impl.cc


### PR DESCRIPTION
Use `GNUInstallDirs` instead that makes gr-rigexpert compatible with GnuRadio 3.11.

See https://github.com/gnuradio/gnuradio/pull/7768 for details.